### PR TITLE
Feature/vta 700

### DIFF
--- a/src/main/java/util/TestUtils.java
+++ b/src/main/java/util/TestUtils.java
@@ -8,4 +8,14 @@ public class TestUtils {
         activitiesSteps.validateActivityErrorTypeWithProperty(field, errorMessage);
     }
 
+    public void getActivitiesTestParams(ActivitiesSteps activitiesSteps, Integer statusCode, String stringData) {
+        activitiesSteps.statusCodeShouldBe(statusCode);
+        activitiesSteps.validateData(stringData);
+    }
+
+    public void postActivitiesTestParams(ActivitiesSteps activitiesSteps) {
+        activitiesSteps.statusCodeShouldBe(201);
+        activitiesSteps.responseShouldContainId();
+
+    }
 }

--- a/src/main/java/util/TestUtils.java
+++ b/src/main/java/util/TestUtils.java
@@ -1,0 +1,11 @@
+package util;
+
+import steps.ActivitiesSteps;
+
+public class TestUtils {
+    public void postActivitiesNegTestParams(ActivitiesSteps activitiesSteps, Integer statusCode, String field, String errorMessage) {
+        activitiesSteps.statusCodeShouldBe(statusCode);
+        activitiesSteps.validateActivityErrorTypeWithProperty(field, errorMessage);
+    }
+
+}

--- a/src/test/java/activities/GetActivities.java
+++ b/src/test/java/activities/GetActivities.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import steps.ActivitiesSteps;
 import util.DataUtil;
 import util.JsonPathAlteration;
+import util.TestUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -22,7 +23,7 @@ public class GetActivities {
 
     @Steps
     ActivitiesSteps activitiesSteps;
-
+    TestUtils testUtils =new TestUtils();
     ActivitiesGet.Builder activitiesData = ActivitiesData.buildActivitiesIdData();
 
 
@@ -30,8 +31,8 @@ public class GetActivities {
     @Test
     public void postActivitiesActivityTypeVisiRt() {
         activitiesSteps.getActivities("", null, null, "", "");
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateData("Bad Request");
+        testUtils.getActivitiesTestParams(activitiesSteps, 400,"Bad Request");
+
     }
 
 
@@ -39,8 +40,8 @@ public class GetActivities {
     @Test
     public void postActivitiesActivityTypeVisiRts() {
         activitiesSteps.getActivities(RandomStringUtils.randomAlphanumeric(6), null, null, DataUtil.buildCurrentDateTime(-1), DataUtil.buildCurrentDateTime(-1));
-        activitiesSteps.statusCodeShouldBe(404);
-        activitiesSteps.validateData("No resources match the search criteria");
+        testUtils.getActivitiesTestParams(activitiesSteps, 404,"No resources match the search criteria");
+
     }
 
 
@@ -48,8 +49,8 @@ public class GetActivities {
     @Test
     public void postActivitiesActivityTypeVisiRt2s() {
         activitiesSteps.getActivities("visit", RandomStringUtils.randomAlphanumeric(45), null, DataUtil.buildCurrentDateTime(-1), DataUtil.buildCurrentDateTime(-1));
-        activitiesSteps.statusCodeShouldBe(404);
-        activitiesSteps.validateData("No resources match the search criteria");
+        testUtils.getActivitiesTestParams(activitiesSteps, 404,"No resources match the search criteria");
+
     }
 
 
@@ -57,24 +58,24 @@ public class GetActivities {
     @Test
     public void postActivitiesActivityTypeVisit() {
         activitiesSteps.getActivities("visit", null, RandomStringUtils.randomAlphanumeric(45), DataUtil.buildCurrentDateTime(-1), DataUtil.buildCurrentDateTime(-1));
-        activitiesSteps.statusCodeShouldBe(404);
-        activitiesSteps.validateData("No resources match the search criteria");
+        testUtils.getActivitiesTestParams(activitiesSteps, 404,"No resources match the search criteria");
+
     }
 
     @Title("CVSB- / CVSB- - AC7 ")
     @Test
     public void postActivitiesActivityTypeVisit2() {
         activitiesSteps.getActivities("visit", null, null, DataUtil.buildCurrentDateTime(-1), RandomStringUtils.randomAlphanumeric(45));
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateData("Bad Request");
+        testUtils.getActivitiesTestParams(activitiesSteps, 400,"Bad Request");
+
     }
 
     @Title("CVSB- / CVSB- - AC7 ")
     @Test
     public void postActivitiesActivityTypeVisit222() {
         activitiesSteps.getActivities("visit", null, null, RandomStringUtils.randomAlphanumeric(45), RandomStringUtils.randomAlphanumeric(45));
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateData("Bad Request");
+        testUtils.getActivitiesTestParams(activitiesSteps, 400,"Bad Request");
+
     }
 
     @Title("CVSB- / CVSB- - AC7 ")
@@ -205,8 +206,8 @@ public class GetActivities {
         String id = activitiesSteps.checkAndGetResponseId();
         activitiesData.setId(id);
         activitiesSteps.getActivities(null, DataUtil.generateRandomExcludingValues(activitiesData.build().getTesterStaffId().length(), activitiesData.build().getTesterStaffId()), null, DataUtil.buildCurrentDateTime(-1), null);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateData("Bad Request");
+        testUtils.getActivitiesTestParams(activitiesSteps, 400,"Bad Request");
+
     }
 
 

--- a/src/test/java/activities/PostActivities.java
+++ b/src/test/java/activities/PostActivities.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.ActivitiesSteps;
 import util.JsonPathAlteration;
+import util.TestUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -23,14 +24,15 @@ import java.util.List;
 public class PostActivities {
     @Steps
     ActivitiesSteps activitiesSteps;
+    TestUtils testUtils =new TestUtils();
+
 
     @Title("CVSB-163 / CVSB-2874 - AC8 API Consumer creates a new activity - activity type: visit")
     @Test
     public void postActivitiesActivityTypeVisit() {
         activitiesSteps.postActivities(ActivitiesData.buildActivitiesIdData().setActivityType("visit").build());
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+ }
 
     @Title("CVSB-163 / CVSB-2874 - AC8 API Consumer creates a new activity - activity type: wait")
     @Test
@@ -56,9 +58,8 @@ public class PostActivities {
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime, alterationTestStationPNumber));
         activitiesSteps.postActivitiesParentIdWithAlterations(postRequestBody, alterations);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+ }
 
     @Title("CVSB-179 / CVSB-4545 / CVSB-4547 - Save wait time in the BE (time is Equal to 5 minutes)")
     @Test
@@ -84,9 +85,8 @@ public class PostActivities {
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime, alterationTestStationPNumber));
         activitiesSteps.postActivitiesParentIdWithAlterations(postRequestBody, alterations);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+ }
 
     @Title("CVSB-179 / CVSB-4544 / CVSB-4543 - Save wait time in the BE (time is Greater than 5 minutes)")
     @Test
@@ -112,9 +112,8 @@ public class PostActivities {
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime, alterationTestStationPNumber));
         activitiesSteps.postActivitiesParentIdWithAlterations(postRequestBody, alterations);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+ }
 
     @Title("CVSB-179 / CVSB-4545 / CVSB-4547 / CVSB-4551 / CVSB-4552 / CVSB-4554 / CVSB-4556 - Save wait time in the BE (time is Equal to 5 minutes)")
     @Test
@@ -140,9 +139,8 @@ public class PostActivities {
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime, alterationTestStationPNumber));
         activitiesSteps.postActivitiesParentIdWithAlterations(postRequestBody, alterations);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+  }
 
     @Title("CVSB-179 / CVSB-4548 / CVSB-4543 / CVSB-4549 / CVSB-4553 / CVSB-4555 - Save wait time in the BE (time is Greater than 5 minutes)")
     @Test
@@ -168,9 +166,8 @@ public class PostActivities {
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime, alterationTestStationPNumber));
         activitiesSteps.postActivitiesParentIdWithAlterations(postRequestBody, alterations);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+  }
 
     @Title("CVSB-179 / CVSB-4557 / CVSB-4558 / CVSB-4562 - AC M5 Save wait time in the BE")
     @Test
@@ -197,9 +194,8 @@ public class PostActivities {
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime, alterationActivityType, alterationTestStationPNumber));
         activitiesSteps.postActivitiesParentIdWithAlterations(postRequestBody, alterations);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+   }
 
     @Title("CVSB-179 / CVSB-4559 / CVSB-4560 / CVSB-4561 /  - AC M6 Save wait time in the BE")
     @Test
@@ -227,33 +223,29 @@ public class PostActivities {
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime, alterationActivityType, alterationTestStationPNumber));
         activitiesSteps.postActivitiesParentIdWithAlterations(postRequestBody, alterations);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+   }
 
     @Title("CVSB-163 / CVSB-2874 - AC8 API Consumer creates a new activity - test station type: atf")
     @Test
     public void postActivitiesTestStationTypeAtf() {
         activitiesSteps.postActivities(ActivitiesData.buildActivitiesIdData().setTestStationType("atf").build());
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
+        testUtils.postActivitiesTestParams(activitiesSteps);
     }
 
     @Title("CVSB-163 / CVSB-2874 - AC8 API Consumer creates a new activity - test station type: gvts")
     @Test
     public void postActivitiesTestStationTypeGvts() {
         activitiesSteps.postActivities(ActivitiesData.buildActivitiesIdData().setTestStationType("gvts").build());
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+ }
 
     @Title("CVSB-163 / CVSB-2874 - AC8 API Consumer creates a new activity - test station type: hq")
     @Test
     public void postActivitiesTestStationTypeHq() {
         activitiesSteps.postActivities(ActivitiesData.buildActivitiesIdData().setTestStationType("hq").build());
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+  }
 
 
     @Title("CVSB-163 / CVSB-2928 -  API Consumer with ended activity creates a new activity")
@@ -269,9 +261,7 @@ public class PostActivities {
         activitiesSteps.putActivitiesEnd(id);
         activitiesSteps.statusCodeShouldBe(200);
         activitiesSteps.postActivities(activitiesData);
-        activitiesSteps.statusCodeShouldBe(201);
-        activitiesSteps.responseShouldContainId();
-
-    }
+        testUtils.postActivitiesTestParams(activitiesSteps);
+ }
 
 }

--- a/src/test/java/activities/PostActivitiesNeg.java
+++ b/src/test/java/activities/PostActivitiesNeg.java
@@ -9,7 +9,6 @@ import net.serenitybdd.junit.runners.SerenityRunner;
 import net.thucydides.core.annotations.Steps;
 import net.thucydides.core.annotations.Title;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.time.DateUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import steps.ActivitiesSteps;

--- a/src/test/java/activities/PostActivitiesNeg.java
+++ b/src/test/java/activities/PostActivitiesNeg.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import steps.ActivitiesSteps;
 import util.DataUtil;
 import util.JsonPathAlteration;
+import util.TestUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -27,17 +28,15 @@ public class PostActivitiesNeg {
 
     @Steps
     ActivitiesSteps activitiesSteps;
-
+    TestUtils testUtils =new TestUtils();
     private Activities.Builder activitiesData = ActivitiesData.buildActivitiesIdData();
-
 
     @Title("CVSB-163 / CVSB-2929 - API Consumer tries to create an activity with missing request body property - activityType")
     @Test
     public void activityActivityTypeMissing() {
 
         activitiesSteps.postActivities(activitiesData.build(), "activityType", ToTypeConvertor.MISSING);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("activityType", "is required");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"activityType", "is required");
     }
 
 
@@ -46,8 +45,7 @@ public class PostActivitiesNeg {
     public void activityActivityTypeNull() {
 
         activitiesSteps.postActivities(activitiesData.build(), "activityType", ToTypeConvertor.NULL);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("activityType", "must be one of [visit, wait, unaccountable time]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps,400,"activityType", "must be one of [visit, wait, unaccountable time]");
     }
 
     @Title("CVSB-163 / CVSB-2931 - API Consumer tries to create an activity with different request body property type - activityType")
@@ -55,8 +53,7 @@ public class PostActivitiesNeg {
     public void activityActivityTypeInteger() {
 
         activitiesSteps.postActivities(activitiesData.build(), "activityType", RandomStringUtils.randomNumeric(6), ToTypeConvertor.INTEGER);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("activityType", "must be one of [visit, wait, unaccountable time]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps,400,"activityType","must be one of [visit, wait, unaccountable time]");
     }
 
     @Title("CVSB-163 / CVSB-2940 - API Consumer tries to create an activity with different range or format body property value - activityType")
@@ -64,8 +61,7 @@ public class PostActivitiesNeg {
     public void activityActivityTypeRandomString() {
 
         activitiesSteps.postActivities(activitiesData.setActivityType(RandomStringUtils.randomAlphanumeric(6)).build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("activityType", "must be one of [visit, wait, unaccountable time]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps,400,"activityType","must be one of [visit, wait, unaccountable time]");
     }
 
     @Title("CVSB-163 / CVSB-2929 - API Consumer tries to create an activity with missing request body property - testStationName")
@@ -73,8 +69,7 @@ public class PostActivitiesNeg {
     public void testStationNameMissing() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationName", ToTypeConvertor.MISSING);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationName", "is required");
+        testUtils.postActivitiesNegTestParams(activitiesSteps,400,"testStationName","is required");
     }
 
 
@@ -83,8 +78,7 @@ public class PostActivitiesNeg {
     public void testStationNameNull() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationName", ToTypeConvertor.NULL);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationName", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationName","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2931 - API Consumer tries to create an activity with different request body property type - testStationName")
@@ -92,8 +86,7 @@ public class PostActivitiesNeg {
     public void testStationNameInteger() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationName", RandomStringUtils.randomNumeric(6), ToTypeConvertor.INTEGER);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationName", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationName","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2929 - API Consumer tries to create an activity with missing request body property - testStationPNumber")
@@ -101,8 +94,7 @@ public class PostActivitiesNeg {
     public void testStationPNumberMissing() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationPNumber", ToTypeConvertor.MISSING);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationPNumber", "is required");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationPNumber","is required");
     }
 
 
@@ -111,8 +103,7 @@ public class PostActivitiesNeg {
     public void testStationPNumberNull() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationPNumber", ToTypeConvertor.NULL);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationPNumber", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationPNumber","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2931 - API Consumer tries to create an activity with different request body property type - testStationPNumber")
@@ -120,8 +111,7 @@ public class PostActivitiesNeg {
     public void testStationPNumberInteger() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationPNumber", RandomStringUtils.randomNumeric(6), ToTypeConvertor.INTEGER);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationPNumber", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationPNumber","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2929 - API Consumer tries to create an activity with missing request body property - testStationEmail")
@@ -129,8 +119,7 @@ public class PostActivitiesNeg {
     public void testStationEmailMissing() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationEmail", ToTypeConvertor.MISSING);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationEmail", "is required");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationEmail","is required");
     }
 
 
@@ -139,8 +128,7 @@ public class PostActivitiesNeg {
     public void testStationEmailNull() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationEmail", ToTypeConvertor.NULL);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationEmail", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationEmail","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2931 - API Consumer tries to create an activity with different request body property type - testStationEmail")
@@ -148,8 +136,7 @@ public class PostActivitiesNeg {
     public void testStationEmailInteger() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationEmail", RandomStringUtils.randomNumeric(6), ToTypeConvertor.INTEGER);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationEmail", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationEmail","must be a string");
     }
 
 
@@ -158,8 +145,7 @@ public class PostActivitiesNeg {
     public void testStationEmailRandomString() {
 
         activitiesSteps.postActivities(activitiesData.setTestStationEmail(RandomStringUtils.randomAlphanumeric(6)).build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationEmail", "must be a valid email");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationEmail","must be a valid email");
     }
 
 
@@ -168,8 +154,7 @@ public class PostActivitiesNeg {
     public void testStationEmailRandomString2() {
 
         activitiesSteps.postActivities(activitiesData.setTestStationEmail(RandomStringUtils.randomAlphanumeric(6) + "@" + RandomStringUtils.randomAlphanumeric(6) + ".").build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationEmail", "must be a valid email");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationEmail","must be a valid email");
     }
 
     @Title("CVSB-163 / CVSB-2940 - API Consumer tries to create an activity with different range or format body property value - testStationEmail")
@@ -177,8 +162,7 @@ public class PostActivitiesNeg {
     public void testStationEmailRandomString3() {
 
         activitiesSteps.postActivities(activitiesData.setTestStationEmail(RandomStringUtils.randomAlphanumeric(6) + "@." + RandomStringUtils.randomAlphanumeric(6)).build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationEmail", "must be a valid email");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationEmail","must be a valid email");
     }
 
     @Title("CVSB-163 / CVSB-2929 - API Consumer tries to create an activity with missing request body property - activityType")
@@ -186,8 +170,7 @@ public class PostActivitiesNeg {
     public void activityTestStationTypeMissing() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationType", ToTypeConvertor.MISSING);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationType", "is required");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationType","is required");
     }
 
 
@@ -196,8 +179,7 @@ public class PostActivitiesNeg {
     public void activityTestStationTypeNull() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationType", ToTypeConvertor.NULL);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationType", "must be one of [atf, gvts, hq]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationType","must be one of [atf, gvts, hq]");
     }
 
     @Title("CVSB-163 / CVSB-2931 - API Consumer tries to create an activity with different request body property type - testStationType")
@@ -205,8 +187,7 @@ public class PostActivitiesNeg {
     public void activityTestStationTypeInteger() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testStationType", RandomStringUtils.randomNumeric(6), ToTypeConvertor.INTEGER);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationType", "must be one of [atf, gvts, hq]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationType","must be one of [atf, gvts, hq]");
     }
 
     @Title("CVSB-163 / CVSB-2940 - API Consumer tries to create an activity with different range or format body property value - testStationType")
@@ -214,8 +195,7 @@ public class PostActivitiesNeg {
     public void activityTestStationTypeString() {
 
         activitiesSteps.postActivities(activitiesData.setTestStationType(RandomStringUtils.randomAlphanumeric(6)).build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationType", "must be one of [atf, gvts, hq]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationType","must be one of [atf, gvts, hq]");
     }
 
     @Title("CVSB-163 / CVSB-2929 - API Consumer tries to create an activity with missing request body property - testerName")
@@ -223,8 +203,7 @@ public class PostActivitiesNeg {
     public void testerNameMissing() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testerName", ToTypeConvertor.MISSING);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testerName", "is required");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testerName","is required");
     }
 
 
@@ -233,8 +212,7 @@ public class PostActivitiesNeg {
     public void testerNameNull() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testerName", ToTypeConvertor.NULL);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testerName", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testerName","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2931 - API Consumer tries to create an activity with different request body property type - testerName")
@@ -242,8 +220,7 @@ public class PostActivitiesNeg {
     public void testerNameInteger() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testerName", RandomStringUtils.randomNumeric(6), ToTypeConvertor.INTEGER);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testerName", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testerName","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2929 - API Consumer tries to create an activity with missing request body property - testerStaffId")
@@ -251,8 +228,7 @@ public class PostActivitiesNeg {
     public void testerStaffIdMissing() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testerStaffId", ToTypeConvertor.MISSING);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testerStaffId", "is required");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testerStaffId", "is required");
     }
 
 
@@ -261,8 +237,7 @@ public class PostActivitiesNeg {
     public void testerStaffIdNull() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testerStaffId", ToTypeConvertor.NULL);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testerStaffId", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testerStaffId","must be a string");
     }
 
     @Title("CVSB-163 / CVSB-2931 - API Consumer tries to create an activity with different request body property type - testerStaffId")
@@ -270,8 +245,7 @@ public class PostActivitiesNeg {
     public void testerStaffIdInteger() {
 
         activitiesSteps.postActivities(activitiesData.build(), "testerStaffId", RandomStringUtils.randomNumeric(6), ToTypeConvertor.INTEGER);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testerStaffId", "must be a string");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testerStaffId","must be a string");
     }
 
 
@@ -291,8 +265,8 @@ public class PostActivitiesNeg {
         String propertyName = RandomStringUtils.randomAlphanumeric(10);
 
         activitiesSteps.postActivities(activitiesData.build(), propertyName, RandomStringUtils.randomAlphanumeric(6), ToTypeConvertor.NEW_PROPERTY);
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty(propertyName, "is not allowed");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,propertyName,"is not allowed");
+
     }
 
     @Title("CVSB-163 / CVSB-2943 - API Consumer tries to create an activity with different case for range body property value - activityType visit")
@@ -310,24 +284,21 @@ public class PostActivitiesNeg {
     public void postActivitiesActivityTypeWaitCaseSensitive() {
 
         activitiesSteps.postActivities(ActivitiesData.buildActivitiesIdData().setActivityType("Wait").build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("activityType", "must be one of [visit, wait, unaccountable time]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"activityType","must be one of [visit, wait, unaccountable time]");
     }
 
     @Title("CVSB-163 / CVSB-2943 - API Consumer tries to create an activity with different case for range body property value - testStationType atf")
     @Test
     public void postActivitiesTestStationTypeAtfCaseSensitive() {
         activitiesSteps.postActivities(ActivitiesData.buildActivitiesIdData().setTestStationType("Atf").build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationType", "must be one of [atf, gvts, hq]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationType","must be one of [atf, gvts, hq]");
     }
 
     @Title("CVSB-163 / CVSB-2943 - API Consumer tries to create an activity with different case for range body property value - testStationType gvts")
     @Test
     public void postActivitiesTestStationTypeGvtsCaseSensitive() {
         activitiesSteps.postActivities(ActivitiesData.buildActivitiesIdData().setTestStationType("Gvts").build());
-        activitiesSteps.statusCodeShouldBe(400);
-        activitiesSteps.validateActivityErrorTypeWithProperty("testStationType", "must be one of [atf, gvts, hq]");
+        testUtils.postActivitiesNegTestParams(activitiesSteps, 400,"testStationType","must be one of [atf, gvts, hq]");
     }
 
     @Title("CVSB-163 / CVSB-2943 - API Consumer tries to create an activity with different case for range body property value - testStationType hq")
@@ -419,7 +390,7 @@ public class PostActivitiesNeg {
                 new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(date), "","REPLACE");
         // create alteration to change waitReason
         //JsonPathAlteration alterationWaitReason = new JsonPathAlteration("$.waitReason",
-                //"[ASdw]", "","REPLACE");
+        //"[ASdw]", "","REPLACE");
         // initialize the alterations list with both declared alteration
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(alterationParentId, alterationStartTime,
                 alterationEndTime));


### PR DESCRIPTION
On vta-700, I created a TestUtil class for a common class for common actions in this ticket and further tickets too. I created a method that first checks the status code and then asserts the fields and errors. I called the "ActivitiesSteps" class like an object by using it as a variable in my method. Calling my new util method in this class, these changes reduced around 60 lines from the code in terms of DRY(don't repeat yourself) code principles.

After creating a testUtil class and using it in “PostActivitiesNeg” I would like to use the rest of them, I chose “GetActivities”, PostActivities”, and “PutActivitiesNeg” because there are many lines which repeat many times. I pick them and reduced them to one line code. My new method does work in these classes too.