### PR TITLE
fix(cb2-4804): allow null preparer values

### DIFF
--- a/src/test/java/testresults/PostTestResultsNegMainLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsNegMainLvlCancelled.java
@@ -817,15 +817,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.validatePostErrorData("preparerId", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - preparerId")
-    @Test
-    public void testResultsNullPreparerId() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "preparerId", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("preparerId", "must be a string");
-    }
-
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - preparerId")
     @Test
@@ -845,17 +836,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("preparerName", "is required");
     }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - preparerName")
-    @Test
-    public void testResultsNullPreparerName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "preparerName", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("preparerName", "must be a string");
-    }
-
-
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - preparerName")
     @Test

--- a/src/test/java/testresults/PostTestResultsNegMainLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsNegMainLvlSubmitted.java
@@ -836,17 +836,6 @@ public class PostTestResultsNegMainLvlSubmitted {
         testResultsSteps.validatePostErrorData("preparerId", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - preparerId")
-    @Test
-    public void testResultsNullPreparerId() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "preparerId", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("preparerId", "must be a string");
-    }
-
-
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - preparerId")
     @Test
     public void testResultsIntegerPreparerId() {
@@ -864,16 +853,6 @@ public class PostTestResultsNegMainLvlSubmitted {
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("preparerName", "is required");
     }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - preparerName")
-    @Test
-    public void testResultsNullPreparerName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "preparerName", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("preparerName", "must be a string");
-    }
-
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - preparerName")
     @Test

--- a/src/test/java/testresults/PostTestResultsPozMainLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsPozMainLvlCancelled.java
@@ -741,6 +741,18 @@ public class PostTestResultsPozMainLvlCancelled {
         validateSavedDataOld();
     }
 
+    @Title("CB2-4804 - API Consumer creates a new test results for submitted/canceled with null - preparerId")
+    @Test
+    public void testResultsNullPreparerId() {
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setPreparerId(null).build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+    }
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - preparerName")
     @Test
     public void testResultsRandomStringPreparerName() {
@@ -768,6 +780,18 @@ public class PostTestResultsPozMainLvlCancelled {
         vehicleCancelledDataOld.setPreparerName(null);
         testResultsSteps.validateData("Test records created");
         validateSavedDataOld();
+    }
+
+    @Title("CB2-4804 - API Consumer creates a new test results for submitted/canceled with null - preparerName")
+    @Test
+    public void testResultsNullPreparerName() {
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setPreparerName(null).build());
+
+        testResultsSteps.statusCodeShouldBe(201);
     }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3504 - TCD - API Consumer creates a new test result for submitted/canceled that allows null values - euVehicleCategory")

--- a/src/test/java/testresults/PostTestResultsPozMainLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsPozMainLvlSubmitted.java
@@ -45,7 +45,7 @@ public class PostTestResultsPozMainLvlSubmitted {
         String jsonFileName = "test-results_post_payload_psv_10300.json";
         test_results_post_payload_psv_10300_json = GenericData.updateJson( jsonFileName, false);
     }
-    
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testStationName")
     @Test
     public void testResultsTestStationNameRandString() {
@@ -1334,6 +1334,35 @@ public class PostTestResultsPozMainLvlSubmitted {
         testResultsSteps.validateData("Test records created");
     }
 
+    @Title("CB2-4804 - API Consumer creates a new test result for submitted/canceled with null - preparerId")
+    @Test
+    public void testResultsNullPreparerId() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber, "systemNumber", "ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationPreparerId = new JsonPathAlteration("$.preparerId", null, "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationPreparerId,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - preparerName")
     @Test
     public void testResultsRandomStringPreparerName() {
@@ -1392,6 +1421,34 @@ public class PostTestResultsPozMainLvlSubmitted {
         testResultsSteps.validateData("Test records created");
     }
 
+    @Title("CB2-4804 - API Consumer creates a new test result for submitted/canceled with null - preparerName")
+    @Test
+    public void testResultsNullPreparerName() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationPreparerName = new JsonPathAlteration("$.preparerName", null, "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationPreparerName,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - euVehicleCategory m1")
     @Test


### PR DESCRIPTION
Adds tests to verify the validation now allows the `preparerId` and `preparerName` fields to be POSTed or PUT with `null` values as well as the existing empty string value (`""`).

This change was made because the database converts empty strings to `null`, which means any client, having retrieved a Test Result, would have to modify these values in order to then PUT the same Test Result.
