### PR TITLE
feat(cb2-4934): allow null for empty fields

### DIFF
--- a/src/test/java/testresults/PostTestResultsNegDefectsLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsNegDefectsLvlCancelled.java
@@ -75,14 +75,7 @@ public class PostTestResultsNegDefectsLvlCancelled {
         testResultsSteps.validatePostErrorData("imDescription", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - imDescription")
-    @Test
-    public void testResultsNullImDescription() {
 
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "imDescription", ToTypeConvertor.NULL, TestResultsLevel.DEFECTS);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("imDescription", "must be a string");
-    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - imDescription")
     @Test
@@ -102,14 +95,7 @@ public class PostTestResultsNegDefectsLvlCancelled {
         testResultsSteps.validatePostErrorData("itemDescription", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - itemDescription")
-    @Test
-    public void testResultsNullItemDescription() {
 
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "itemDescription", ToTypeConvertor.NULL, TestResultsLevel.DEFECTS);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("itemDescription", "must be a string");
-    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - itemDescription")
     @Test
@@ -127,15 +113,6 @@ public class PostTestResultsNegDefectsLvlCancelled {
         testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "deficiencyRef", ToTypeConvertor.MISSING, TestResultsLevel.DEFECTS);
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("deficiencyRef", "is required");
-    }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - deficiencyRef")
-    @Test
-    public void testResultsNullDeficiencyRef() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "deficiencyRef", ToTypeConvertor.NULL, TestResultsLevel.DEFECTS);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("deficiencyRef", "must be a string");
     }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - deficiencyRef")

--- a/src/test/java/testresults/PostTestResultsNegDefectsLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsNegDefectsLvlSubmitted.java
@@ -62,14 +62,6 @@ public class PostTestResultsNegDefectsLvlSubmitted {
         testResultsSteps.validatePostErrorData("imDescription", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - imDescription")
-    @Test
-    public void testResultsNullImDescription() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedData.setVrm(VRM).build(), "imDescription", ToTypeConvertor.NULL, TestResultsLevel.DEFECTS);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("imDescription", "must be a string");
-    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - imDescription")
     @Test
@@ -89,14 +81,7 @@ public class PostTestResultsNegDefectsLvlSubmitted {
         testResultsSteps.validatePostErrorData("itemDescription", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - itemDescription")
-    @Test
-    public void testResultsNullItemDescription() {
 
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedData.setVrm(VRM).build(), "itemDescription", ToTypeConvertor.NULL, TestResultsLevel.DEFECTS);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("itemDescription", "must be a string");
-    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - itemDescription")
     @Test
@@ -116,14 +101,6 @@ public class PostTestResultsNegDefectsLvlSubmitted {
         testResultsSteps.validatePostErrorData("deficiencyRef", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - deficiencyRef")
-    @Test
-    public void testResultsNullDeficiencyRef() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedData.setVrm(VRM).build(), "deficiencyRef", ToTypeConvertor.NULL, TestResultsLevel.DEFECTS);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("deficiencyRef", "must be a string");
-    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - deficiencyRef")
     @Test

--- a/src/test/java/testresults/PostTestResultsNegMainLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsNegMainLvlCancelled.java
@@ -257,7 +257,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.validatePostErrorData("testerName", "length must be less than or equal to 60 characters long");
     }
 
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3505 - API Consumer tries to create a new test result for submitted/canceled with missing property - testerStaffId")
     @Test
     public void testResultsMissingTesterStaffId() {
@@ -267,9 +266,14 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.validatePostErrorData("testerStaffId", "is required");
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerStaffId")
+    @Test
+    public void testResultsNullTesterStaffId() {
 
-
-
+        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testerStaffId", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
+        testResultsSteps.statusCodeShouldBe(400);
+        testResultsSteps.validatePostErrorData("testerStaffId", "must be a string");
+    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testerStaffId")
     @Test

--- a/src/test/java/testresults/PostTestResultsNegMainLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsNegMainLvlCancelled.java
@@ -137,16 +137,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.validatePostErrorData("testStationName", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testStationName")
-    @Test
-    public void testResultsNullTestStationName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testStationName", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testStationName", "must be a string");
-    }
-
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testStationName")
     @Test
     public void testResultsIntegerTestStationName() {
@@ -174,16 +164,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("testStationPNumber", "is required");
     }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testStationPNumber")
-    @Test
-    public void testResultsNullTestStationPNumber() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testStationPNumber", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testStationPNumber", "must be a string");
-    }
-
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testStationPNumber")
     @Test
@@ -259,16 +239,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.validatePostErrorData("testerName", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerName")
-    @Test
-    public void testResultsNullTesterName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testerName", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testerName", "must be a string");
-    }
-
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testerName")
     @Test
     public void testResultsIntegerTesterName() {
@@ -298,14 +268,7 @@ public class PostTestResultsNegMainLvlCancelled {
     }
 
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerStaffId")
-    @Test
-    public void testResultsNullTesterStaffId() {
 
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testerStaffId", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testerStaffId", "must be a string");
-    }
 
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testerStaffId")
@@ -334,15 +297,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testerEmailAddress", ToTypeConvertor.MISSING, TestResultsLevel.MAIN_LEVEL);
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("testerEmailAddress", "is required");
-    }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerEmailAddress")
-    @Test
-    public void testResultsNullTesterEmailAddress() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testerEmailAddress", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testerEmailAddress", "must be a string");
     }
 
 
@@ -508,16 +462,6 @@ public class PostTestResultsNegMainLvlCancelled {
         testResultsSteps.postTestResults(vehicleCancelledData.setVrm(VRM).setTestStatus("").build());
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("testStatus", "should be one of [\"submitted\", \"cancelled\"]");
-    }
-
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - reasonForCancellation")
-    @Test
-    public void testResultsNullReasonForCancellation() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "reasonForCancellation", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("reasonForCancellation", "must be a string");
     }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3505 - API Consumer tries to create a new test result for submitted/canceled with missing property - reasonForCancellation")

--- a/src/test/java/testresults/PostTestResultsNegMainLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsNegMainLvlSubmitted.java
@@ -163,16 +163,6 @@ public class PostTestResultsNegMainLvlSubmitted {
         testResultsSteps.validatePostErrorData("testStationName", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testStationName")
-    @Test
-    public void testResultsNullTestStationName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testStationName", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testStationName", "must be a string");
-    }
-
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testStationName")
     @Test
     public void testResultsIntegerTestStationName() {
@@ -199,15 +189,6 @@ public class PostTestResultsNegMainLvlSubmitted {
         testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testStationPNumber", ToTypeConvertor.MISSING, TestResultsLevel.MAIN_LEVEL);
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("testStationPNumber", "is required");
-    }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testStationPNumber")
-    @Test
-    public void testResultsNullTestStationPNumber() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testStationPNumber", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testStationPNumber", "must be a string");
     }
 
 
@@ -286,16 +267,6 @@ public class PostTestResultsNegMainLvlSubmitted {
         testResultsSteps.validatePostErrorData("testerName", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerName")
-    @Test
-    public void testResultsNullTesterName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testerName", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testerName", "must be a string");
-    }
-
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testerName")
     @Test
     public void testResultsIntegerTesterName() {
@@ -324,14 +295,7 @@ public class PostTestResultsNegMainLvlSubmitted {
     }
 
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerStaffId")
-    @Test
-    public void testResultsNullTesterStaffId() {
 
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testerStaffId", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testerStaffId", "must be a string");
-    }
 
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testerStaffId")
@@ -361,16 +325,6 @@ public class PostTestResultsNegMainLvlSubmitted {
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("testerEmailAddress", "is required");
     }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerEmailAddress")
-    @Test
-    public void testResultsNullTesterEmailAddress() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testerEmailAddress", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testerEmailAddress", "must be a string");
-    }
-
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testerEmailAddress")
     @Test

--- a/src/test/java/testresults/PostTestResultsNegMainLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsNegMainLvlSubmitted.java
@@ -316,6 +316,14 @@ public class PostTestResultsNegMainLvlSubmitted {
         testResultsSteps.validatePostErrorData("testerStaffId", "length must be less than or equal to 36 characters long");
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testerStaffId")
+    @Test
+    public void testResultsNullTesterStaffId() {
+
+        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testerStaffId", ToTypeConvertor.NULL, TestResultsLevel.MAIN_LEVEL);
+        testResultsSteps.statusCodeShouldBe(400);
+        testResultsSteps.validatePostErrorData("testerStaffId", "must be a string");
+    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3505 - API Consumer tries to create a new test result for submitted/canceled with missing property - testerEmailAddress")
     @Test

--- a/src/test/java/testresults/PostTestResultsNegTestTypesCancelledLvl.java
+++ b/src/test/java/testresults/PostTestResultsNegTestTypesCancelledLvl.java
@@ -210,6 +210,15 @@ public class PostTestResultsNegTestTypesCancelledLvl {
         testResultsSteps.validatePostErrorData("testTypeId", "must be a string");
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testTypeId")
+    @Test
+    public void testResultsNullTestTypeId() {
+
+        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testTypeId", ToTypeConvertor.NULL, TestResultsLevel.TEST_TYPES);
+        testResultsSteps.statusCodeShouldBe(400);
+        testResultsSteps.validatePostErrorData("testTypeId", "must be a string");
+    }
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3505 - API Consumer tries to create a new test result for submitted/canceled with missing property - certificateNumber")
     @Test
     public void testResultsCertificateNumber() {

--- a/src/test/java/testresults/PostTestResultsNegTestTypesCancelledLvl.java
+++ b/src/test/java/testresults/PostTestResultsNegTestTypesCancelledLvl.java
@@ -154,15 +154,6 @@ public class PostTestResultsNegTestTypesCancelledLvl {
         testResultsSteps.validatePostErrorData("testTypeName", "is required");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testTypeName")
-    @Test
-    public void testResultsNullTestTypeName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testTypeName", ToTypeConvertor.NULL, TestResultsLevel.TEST_TYPES);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testTypeName", "must be a string");
-    }
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testTypeName")
     @Test
     public void testResultsIntegerTestTypeName() {
@@ -208,15 +199,6 @@ public class PostTestResultsNegTestTypesCancelledLvl {
         testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testTypeId", ToTypeConvertor.MISSING, TestResultsLevel.TEST_TYPES);
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("testTypeId", "is required");
-    }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testTypeId")
-    @Test
-    public void testResultsNullTestTypeId() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleCancelledData.setVrm(VRM).build(), "testTypeId", ToTypeConvertor.NULL, TestResultsLevel.TEST_TYPES);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testTypeId", "must be a string");
     }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testTypeId")

--- a/src/test/java/testresults/PostTestResultsNegTestTypesSubmittedLvl.java
+++ b/src/test/java/testresults/PostTestResultsNegTestTypesSubmittedLvl.java
@@ -215,6 +215,15 @@ public class PostTestResultsNegTestTypesSubmittedLvl {
         testResultsSteps.validatePostErrorData("testTypeId", "is required");
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testTypeId")
+    @Test
+    public void testResultsNullTestTypeId() {
+
+        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testTypeId", ToTypeConvertor.NULL, TestResultsLevel.TEST_TYPES);
+        testResultsSteps.statusCodeShouldBe(400);
+        testResultsSteps.validatePostErrorData("testTypeId", "must be a string");
+    }
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testTypeId")
     @Test
     public void testResultsIntegerTestTypeId() {

--- a/src/test/java/testresults/PostTestResultsNegTestTypesSubmittedLvl.java
+++ b/src/test/java/testresults/PostTestResultsNegTestTypesSubmittedLvl.java
@@ -168,16 +168,6 @@ public class PostTestResultsNegTestTypesSubmittedLvl {
         testResultsSteps.validatePostErrorData("testTypeName", "is required");
     }
 
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testTypeName")
-    @Test
-    public void testResultsNullTestTypeName() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testTypeName", ToTypeConvertor.NULL, TestResultsLevel.TEST_TYPES);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testTypeName", "must be a string");
-    }
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testTypeName")
     @Test
     public void testResultsIntegerTestTypeName() {
@@ -223,15 +213,6 @@ public class PostTestResultsNegTestTypesSubmittedLvl {
         testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testTypeId", ToTypeConvertor.MISSING, TestResultsLevel.TEST_TYPES);
         testResultsSteps.statusCodeShouldBe(400);
         testResultsSteps.validatePostErrorData("testTypeId", "is required");
-    }
-
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - testTypeId")
-    @Test
-    public void testResultsNullTestTypeId() {
-
-        testResultsSteps.postTestResultsFieldChange(vehicleSubmittedDataOld.setVrm(VRM).build(), "testTypeId", ToTypeConvertor.NULL, TestResultsLevel.TEST_TYPES);
-        testResultsSteps.statusCodeShouldBe(400);
-        testResultsSteps.validatePostErrorData("testTypeId", "must be a string");
     }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3508 API Consumer tries to create a new test result for submitted/canceled with different property type - testTypeId")

--- a/src/test/java/testresults/PostTestResultsPozDefectsLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsPozDefectsLvlCancelled.java
@@ -148,6 +148,20 @@ public class PostTestResultsPozDefectsLvlCancelled {
         validateSavedDataOld();
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - imDescription")
+    @Test
+    public void testResultsNullImDescription() {
+
+        ((TestTypes) vehicleCancelledDataOld.getTestTypes().get(0)).getDefects().get(0).setImDescription(null);
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build());
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.build().getTestTypes().get(0).getDefects().get(0).setImDescription(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - itemDescription")
     @Test
@@ -178,6 +192,21 @@ public class PostTestResultsPozDefectsLvlCancelled {
         validateSavedDataOld();
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - itemDescription")
+    @Test
+    public void testResultsNullItemDescription() {
+
+        ((TestTypes) vehicleCancelledDataOld.getTestTypes().get(0)).getDefects().get(0).setItemDescription(null);
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build());
+        vehicleCancelledDataOld.build().getTestTypes().get(0).getDefects().get(0).setItemDescription(null);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - deficiencyRef")
     @Test
@@ -198,6 +227,22 @@ public class PostTestResultsPozDefectsLvlCancelled {
     public void testResultsEmptyDeficiencyRef() {
 
         ((TestTypes) vehicleCancelledDataOld.getTestTypes().get(0)).getDefects().get(0).setDeficiencyRef("");
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build());
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.build().getTestTypes().get(0).getDefects().get(0).setDeficiencyRef(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3504 - API Consumer tries to create a new test result for submitted/canceled with null value - deficiencyRef")
+    @Test
+    public void testResultsNullDeficiencyRef() {
+
+        ((TestTypes) vehicleCancelledDataOld.getTestTypes().get(0)).getDefects().get(0).setDeficiencyRef(null);
 
         testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
                 .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))

--- a/src/test/java/testresults/PostTestResultsPozDefectsLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsPozDefectsLvlSubmitted.java
@@ -31,7 +31,7 @@ public class PostTestResultsPozDefectsLvlSubmitted {
         test_results_post_payload_psv_10300_json = GenericData.updateJson( jsonFileName, false);
         test_results_psv_cert_json = GenericData.updateJson( jsonFileName2, false);
     }
-    
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - imNumber")
     @Test
     public void testResultsRandomImNumber() {
@@ -61,7 +61,7 @@ public class PostTestResultsPozDefectsLvlSubmitted {
         testResultsSteps.validateData("Test records created");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - imDescription")
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - itemDescription")
     @Test
     public void testResultsRandomImDescription() {
 
@@ -90,7 +90,36 @@ public class PostTestResultsPozDefectsLvlSubmitted {
         testResultsSteps.validateData("Test records created");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3486 - API Consumer creates a new test results for submitted/canceled with no min restriction - imDescription - null")
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - itemDescription")
+    @Test
+    public void testResultsNullItemDescription() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationItemDescription = new JsonPathAlteration("$.testTypes[0].defects[0].itemDescription", null, "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationItemDescription,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3486 - API Consumer creates a new test results for submitted/canceled with no min restriction - itemDescription - null")
     @Test
     public void testResultsEmptyImDescription() {
 
@@ -119,6 +148,34 @@ public class PostTestResultsPozDefectsLvlSubmitted {
         testResultsSteps.validateData("Test records created");
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - imDescription")
+    @Test
+    public void testResultsNullImDescription() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationItemDescription = new JsonPathAlteration("$.testTypes[0].defects[0].imDescription", null, "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationItemDescription,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - itemDescription")
     @Test
@@ -703,6 +760,35 @@ public class PostTestResultsPozDefectsLvlSubmitted {
         testResultsSteps.statusCodeShouldBe(201);
         testResultsSteps.validateData("Test records created");
 
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - deficiencyRef")
+    @Test
+    public void testResultsNullDeficiencyRef() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationDeficiencyRef = new JsonPathAlteration("$.testTypes[0].defects[0].deficiencyRef", null, "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationDeficiencyRef,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
     }
 
 

--- a/src/test/java/testresults/PostTestResultsPozMainLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsPozMainLvlCancelled.java
@@ -60,6 +60,21 @@ public class PostTestResultsPozMainLvlCancelled {
         validateSavedDataOld();
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 - API Consumer creates a new test results for submitted/canceled with null value - testStationName")
+    @Test
+    public void testResultsTestStationNameNull() {
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setTestStationName(null).build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.setTestStationName(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testStationPNumber")
     @Test
@@ -83,6 +98,21 @@ public class PostTestResultsPozMainLvlCancelled {
                 .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
                 .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
                 .setTestStationPNumber("").build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.setTestStationPNumber(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testStationPNumber")
+    @Test
+    public void testResultsNullTestStationPNumber() {
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setTestStationPNumber(null).build());
 
         testResultsSteps.statusCodeShouldBe(201);
         vehicleCancelledDataOld.setTestStationPNumber(null);
@@ -161,6 +191,21 @@ public class PostTestResultsPozMainLvlCancelled {
         validateSavedDataOld();
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3486 - API Consumer creates a new test results for submitted/canceled with null value - testerName")
+    @Test
+    public void testResultsNullTesterName() {
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setTesterName(null).build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.setTesterName(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testerStaffId")
     @Test
@@ -191,6 +236,22 @@ public class PostTestResultsPozMainLvlCancelled {
         validateSavedDataOld();
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testerStaffId")
+    @Test
+    public void testResultsNullTesterStaffId() {
+
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setTesterStaffId(null).build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.setTesterStaffId(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testerEmailAddress")
     @Test
@@ -214,6 +275,21 @@ public class PostTestResultsPozMainLvlCancelled {
                 .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
                 .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
                 .setTesterEmailAddress("").build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.setTesterEmailAddress(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testerEmailAddress")
+    @Test
+    public void testResultsNullTesterEmailAddress() {
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setTesterEmailAddress(null).build());
 
         testResultsSteps.statusCodeShouldBe(201);
         vehicleCancelledDataOld.setTesterEmailAddress(null);
@@ -272,6 +348,21 @@ public class PostTestResultsPozMainLvlCancelled {
                 .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
                 .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
                 .setReasonForCancellation("").build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleCancelledDataOld.setReasonForCancellation(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value for not nullable - reasonForCancellation")
+    @Test
+    public void testResultsNullReasonForCancellation() {
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
+                .setReasonForCancellation(null).build());
 
         testResultsSteps.statusCodeShouldBe(201);
         vehicleCancelledDataOld.setReasonForCancellation(null);

--- a/src/test/java/testresults/PostTestResultsPozMainLvlCancelled.java
+++ b/src/test/java/testresults/PostTestResultsPozMainLvlCancelled.java
@@ -236,23 +236,6 @@ public class PostTestResultsPozMainLvlCancelled {
         validateSavedDataOld();
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testerStaffId")
-    @Test
-    public void testResultsNullTesterStaffId() {
-
-
-        testResultsSteps.postTestResults(vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
-                .setSystemNumber(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getSystemNumber()))
-                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm()))
-                .setTesterStaffId(null).build());
-
-        testResultsSteps.statusCodeShouldBe(201);
-        vehicleCancelledDataOld.setTesterStaffId(null);
-        testResultsSteps.validateData("Test records created");
-        validateSavedDataOld();
-    }
-
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testerEmailAddress")
     @Test
     public void testResultsRandomTesterEmailAddress() {

--- a/src/test/java/testresults/PostTestResultsPozMainLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsPozMainLvlSubmitted.java
@@ -104,6 +104,35 @@ public class PostTestResultsPozMainLvlSubmitted {
         testResultsSteps.validateData("Test records created");
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 - API Consumer creates a new test results for submitted/canceled with null value - testStationName")
+    @Test
+    public void testResultsTestStationNameNull() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationTestStationName = new JsonPathAlteration("$.testStationName", null, "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationTestStationName,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testStationPNumber")
     @Test
@@ -149,6 +178,35 @@ public class PostTestResultsPozMainLvlSubmitted {
         JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
         JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
         JsonPathAlteration alterationTestStationPNumber = new JsonPathAlteration("$.testStationPNumber", "", "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationTestStationPNumber,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testStationPNumber")
+    @Test
+    public void testResultsNullTestStationPNumber() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationTestStationPNumber = new JsonPathAlteration("$.testStationPNumber", null, "", "REPLACE");
 
         // Collate the list of alterations.
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
@@ -308,6 +366,35 @@ public class PostTestResultsPozMainLvlSubmitted {
         testResultsSteps.validateData("Test records created");
     }
 
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 - API Consumer creates a new test results for submitted/canceled with null value - testerName")
+    @Test
+    public void testResultsNullTesterName() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationTesterName = new JsonPathAlteration("$.testerName",null , "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationTesterName,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
 
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testerStaffId")
     @Test
@@ -346,6 +433,21 @@ public class PostTestResultsPozMainLvlSubmitted {
                 .setSystemNumber(generateRandomExcludingValues(16, vehicleSubmittedDataOld.build().getSystemNumber()))
                 .setVrm(generateRandomExcludingValues(7, vehicleSubmittedDataOld.build().getVrm()))
                 .setTesterStaffId("").build());
+
+        testResultsSteps.statusCodeShouldBe(201);
+        vehicleSubmittedDataOld.setTesterStaffId(null);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testerStaffId")
+    @Test
+    public void testResultsNullTesterStaffId() {
+
+        testResultsSteps.postTestResults(vehicleSubmittedDataOld.setVin(generateRandomExcludingValues(21, vehicleSubmittedDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(16, vehicleSubmittedDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleSubmittedDataOld.build().getVrm()))
+                .setTesterStaffId(null).build());
 
         testResultsSteps.statusCodeShouldBe(201);
         vehicleSubmittedDataOld.setTesterStaffId(null);
@@ -398,6 +500,35 @@ public class PostTestResultsPozMainLvlSubmitted {
         JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
         JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
         JsonPathAlteration alterationTesterEmailAddress = new JsonPathAlteration("$.testerEmailAddress", "", "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationTesterEmailAddress,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testerEmailAddress")
+    @Test
+    public void testResultsNullTesterEmailAddress() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationTesterEmailAddress = new JsonPathAlteration("$.testerEmailAddress", null, "", "REPLACE");
 
         // Collate the list of alterations.
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(

--- a/src/test/java/testresults/PostTestResultsPozMainLvlSubmitted.java
+++ b/src/test/java/testresults/PostTestResultsPozMainLvlSubmitted.java
@@ -440,22 +440,6 @@ public class PostTestResultsPozMainLvlSubmitted {
         validateSavedDataOld();
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testerStaffId")
-    @Test
-    public void testResultsNullTesterStaffId() {
-
-        testResultsSteps.postTestResults(vehicleSubmittedDataOld.setVin(generateRandomExcludingValues(21, vehicleSubmittedDataOld.build().getVin()))
-                .setSystemNumber(generateRandomExcludingValues(16, vehicleSubmittedDataOld.build().getSystemNumber()))
-                .setVrm(generateRandomExcludingValues(7, vehicleSubmittedDataOld.build().getVrm()))
-                .setTesterStaffId(null).build());
-
-        testResultsSteps.statusCodeShouldBe(201);
-        vehicleSubmittedDataOld.setTesterStaffId(null);
-        testResultsSteps.validateData("Test records created");
-        validateSavedDataOld();
-    }
-
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testerEmailAddress")
     @Test
     public void testResultsRandomTesterEmailAddress() {

--- a/src/test/java/testresults/PostTestResultsPozTestTypesCancelledLvl.java
+++ b/src/test/java/testresults/PostTestResultsPozTestTypesCancelledLvl.java
@@ -135,21 +135,6 @@ public class PostTestResultsPozTestTypesCancelledLvl {
         testResultsSteps.validateData("Test records created");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testTypeId")
-    @Test
-    public void testResultsNullTestTypeId() {
-
-        vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
-                .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
-                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build()
-                .getTestTypes().get(0).setTestTypeId(null);
-
-        testResultsSteps.postTestResults(vehicleCancelledDataOld.build());
-        vehicleCancelledDataOld.build().getTestTypes().get(0).setTestTypeId(null);
-        testResultsSteps.statusCodeShouldBe(201);
-        testResultsSteps.validateData("Test records created");
-    }
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - certificateNumber")
     @Test
     public void testResultsRandomCertificateNumber() {

--- a/src/test/java/testresults/PostTestResultsPozTestTypesCancelledLvl.java
+++ b/src/test/java/testresults/PostTestResultsPozTestTypesCancelledLvl.java
@@ -43,7 +43,7 @@ public class PostTestResultsPozTestTypesCancelledLvl {
         String jsonFileName = "test-results_cancelled.json";
         test_results_cancelled_json = GenericData.updateJson( jsonFileName, false);
     }
-    
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testTypeName")
     @Test
     public void testResultsRandomTestTypeName() {
@@ -67,6 +67,22 @@ public class PostTestResultsPozTestTypesCancelledLvl {
                 .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
                 .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build()
                 .getTestTypes().get(0).setTestTypeName("");
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.build());
+        vehicleCancelledDataOld.build().getTestTypes().get(0).setTestTypeName(null);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+        validateSavedDataOld();
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testTypeName")
+    @Test
+    public void testResultsNullTestTypeName() {
+
+        vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build()
+                .getTestTypes().get(0).setTestTypeName(null);
 
         testResultsSteps.postTestResults(vehicleCancelledDataOld.build());
         vehicleCancelledDataOld.build().getTestTypes().get(0).setTestTypeName(null);
@@ -112,6 +128,21 @@ public class PostTestResultsPozTestTypesCancelledLvl {
                 .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
                 .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build()
                 .getTestTypes().get(0).setTestTypeId("");
+
+        testResultsSteps.postTestResults(vehicleCancelledDataOld.build());
+        vehicleCancelledDataOld.build().getTestTypes().get(0).setTestTypeId(null);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testTypeId")
+    @Test
+    public void testResultsNullTestTypeId() {
+
+        vehicleCancelledDataOld.setVin(generateRandomExcludingValues(21, vehicleCancelledDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(16, vehicleCancelledDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleCancelledDataOld.build().getVrm())).build()
+                .getTestTypes().get(0).setTestTypeId(null);
 
         testResultsSteps.postTestResults(vehicleCancelledDataOld.build());
         vehicleCancelledDataOld.build().getTestTypes().get(0).setTestTypeId(null);
@@ -315,7 +346,7 @@ public class PostTestResultsPozTestTypesCancelledLvl {
         testResultsSteps.validateData("Test records created");
         validateSavedDataOld();
     }
-    
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3504 - TCD - API Consumer creates a new test result for submitted/canceled that allows null values - seatbeltInstallationCheckDate")
     @Test
     public void testResultsNullSeatbeltInstallationCheckDate() {

--- a/src/test/java/testresults/PostTestResultsPozTestTypesSubmittedLvl.java
+++ b/src/test/java/testresults/PostTestResultsPozTestTypesSubmittedLvl.java
@@ -189,21 +189,6 @@ public class PostTestResultsPozTestTypesSubmittedLvl {
         testResultsSteps.validateData("Test records created");
     }
 
-    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testTypeId")
-    @Test
-    public void testResultsNullTestTypeId() {
-
-        vehicleSubmittedDataOld.setVin(generateRandomExcludingValues(21, vehicleSubmittedDataOld.build().getVin()))
-                .setSystemNumber(generateRandomExcludingValues(16, vehicleSubmittedDataOld.build().getSystemNumber()))
-                .setVrm(generateRandomExcludingValues(7, vehicleSubmittedDataOld.build().getVrm())).build()
-                .getTestTypes().get(0).setTestTypeId(null);
-
-        testResultsSteps.postTestResults(vehicleSubmittedDataOld.build());
-        vehicleSubmittedDataOld.build().getTestTypes().get(0).setTestTypeId(null);
-        testResultsSteps.statusCodeShouldBe(201);
-        testResultsSteps.validateData("Test records created");
-    }
-
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - certificateNumber")
     @Test
     public void testResultsRandomCertificateNumber() {

--- a/src/test/java/testresults/PostTestResultsPozTestTypesSubmittedLvl.java
+++ b/src/test/java/testresults/PostTestResultsPozTestTypesSubmittedLvl.java
@@ -42,7 +42,7 @@ public class PostTestResultsPozTestTypesSubmittedLvl {
         String jsonFileName = "test-results_post_payload_psv_10300.json";
         test_results_post_payload_psv_10300_json = GenericData.updateJson( jsonFileName, false);
     }
-    
+
     @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-1573 - Consumer creates a new test results for the submitted/cancelled test - testTypeName")
     @Test
     public void testResultsRandomTestTypeName() {
@@ -87,6 +87,35 @@ public class PostTestResultsPozTestTypesSubmittedLvl {
         JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
         JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
         JsonPathAlteration alterationTestTypeName = new JsonPathAlteration("$.testTypes[0].testTypeName", "", "", "REPLACE");
+
+        // Collate the list of alterations.
+        List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
+                alterationVin,
+                alterationSystemNumber,
+                alterationTestTypeName,
+                alterationTestResultId));
+
+        // Post the results, together with any alterations, and verify that they are accepted.
+        testResultsSteps.postVehicleTestResultsWithAlterations(testResultRecord, alterations);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testTypeName")
+    @Test
+    public void testResultsNullTestTypeName() {
+
+        // Read the base test result JSON.
+        String testResultRecord = test_results_post_payload_psv_10300_json;
+
+        // Create alteration to add one more tech record to in the request body
+        String randomVin = GenericData.generateRandomVin();
+        String randomTestResultId = UUID.randomUUID().toString();
+        String randomSystemNumber = GenericData.generateRandomSystemNumber();
+        JsonPathAlteration alterationSystemNumber = new JsonPathAlteration("$", randomSystemNumber,"systemNumber","ADD_FIELD");
+        JsonPathAlteration alterationVin = new JsonPathAlteration("$.vin", randomVin, "", "REPLACE");
+        JsonPathAlteration alterationTestResultId = new JsonPathAlteration("$.testResultId", randomTestResultId, "", "REPLACE");
+        JsonPathAlteration alterationTestTypeName = new JsonPathAlteration("$.testTypes[0].testTypeName", null, "", "REPLACE");
 
         // Collate the list of alterations.
         List<JsonPathAlteration> alterations = new ArrayList<>(Arrays.asList(
@@ -153,6 +182,21 @@ public class PostTestResultsPozTestTypesSubmittedLvl {
                 .setSystemNumber(generateRandomExcludingValues(16, vehicleSubmittedDataOld.build().getSystemNumber()))
                 .setVrm(generateRandomExcludingValues(7, vehicleSubmittedDataOld.build().getVrm())).build()
                 .getTestTypes().get(0).setTestTypeId("");
+
+        testResultsSteps.postTestResults(vehicleSubmittedDataOld.build());
+        vehicleSubmittedDataOld.build().getTestTypes().get(0).setTestTypeId(null);
+        testResultsSteps.statusCodeShouldBe(201);
+        testResultsSteps.validateData("Test records created");
+    }
+
+    @Title("CVSB-417 - CVSB-949 - CVSB-1140 / CVSB-3506 - API Consumer tries to create a new test result for submitted/canceled with null value - testTypeId")
+    @Test
+    public void testResultsNullTestTypeId() {
+
+        vehicleSubmittedDataOld.setVin(generateRandomExcludingValues(21, vehicleSubmittedDataOld.build().getVin()))
+                .setSystemNumber(generateRandomExcludingValues(16, vehicleSubmittedDataOld.build().getSystemNumber()))
+                .setVrm(generateRandomExcludingValues(7, vehicleSubmittedDataOld.build().getVrm())).build()
+                .getTestTypes().get(0).setTestTypeId(null);
 
         testResultsSteps.postTestResults(vehicleSubmittedDataOld.build());
         vehicleSubmittedDataOld.build().getTestTypes().get(0).setTestTypeId(null);


### PR DESCRIPTION
Fixes the regression pack by amending the tests following the changes to the test-results service validation which now allow `null` values where `""` (empty strings) were allowed.