### PR TITLE
feat(cb2-6669): amend tests for new promotion of provisional to current logic

### DIFF
--- a/src/test/java/testresults/PostTestResultsMoreVinFirstTest.java
+++ b/src/test/java/testresults/PostTestResultsMoreVinFirstTest.java
@@ -214,7 +214,7 @@ public class PostTestResultsMoreVinFirstTest {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "archived");
+        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
     }
 
@@ -390,7 +390,7 @@ public class PostTestResultsMoreVinFirstTest {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "archived");
+        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
 
     }

--- a/src/test/java/testresults/PostTestResultsMoreVinFirstTest.java
+++ b/src/test/java/testresults/PostTestResultsMoreVinFirstTest.java
@@ -214,7 +214,6 @@ public class PostTestResultsMoreVinFirstTest {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
     }
 
@@ -390,7 +389,6 @@ public class PostTestResultsMoreVinFirstTest {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
 
     }

--- a/src/test/java/testresults/PostTestResultsMoreVinNotifiableAlteration.java
+++ b/src/test/java/testresults/PostTestResultsMoreVinNotifiableAlteration.java
@@ -212,7 +212,6 @@ public class PostTestResultsMoreVinNotifiableAlteration {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
 
 
@@ -397,7 +396,6 @@ public class PostTestResultsMoreVinNotifiableAlteration {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
     }
 }

--- a/src/test/java/testresults/PostTestResultsMoreVinNotifiableAlteration.java
+++ b/src/test/java/testresults/PostTestResultsMoreVinNotifiableAlteration.java
@@ -212,7 +212,7 @@ public class PostTestResultsMoreVinNotifiableAlteration {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "archived");
+        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
 
 
@@ -397,7 +397,7 @@ public class PostTestResultsMoreVinNotifiableAlteration {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("$.size()", 2);
 
-        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "archived");
+        vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "removed");
         vehicleTechnicalRecordsSteps.valueForFieldInAnyTechRecordShouldBe(systemNumberOne, randomVin, "statusCode", "current");
     }
 }

--- a/src/test/java/testresults/PostTestResultsProvisionalUpdate.java
+++ b/src/test/java/testresults/PostTestResultsProvisionalUpdate.java
@@ -132,7 +132,7 @@ public class PostTestResultsProvisionalUpdate {
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].systemNumber", systemNumber);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].techRecord.size()", 2);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
-                ("[0].techRecord.findAll { it.statusCode == 'archived' }.size()", 1);
+                ("[0].techRecord.findAll { it.statusCode == 'removed' }.size()", 1);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
                 ("[0].techRecord.findAll { it.statusCode == 'current' }.size()", 1);
 

--- a/src/test/java/testresults/PostTestResultsProvisionalUpdate.java
+++ b/src/test/java/testresults/PostTestResultsProvisionalUpdate.java
@@ -130,9 +130,9 @@ public class PostTestResultsProvisionalUpdate {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].vin", randomVin);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].systemNumber", systemNumber);
-        vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].techRecord.size()", 2);
+        vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].techRecord.size()", 1);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
-                ("[0].techRecord.findAll { it.statusCode == 'removed' }.size()", 1);
+                ("[0].techRecord.findAll { it.statusCode == 'removed' }.size()", 0);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
                 ("[0].techRecord.findAll { it.statusCode == 'current' }.size()", 1);
 

--- a/src/test/java/testresults/PostTestResultsProvisionalUpdateFirstTestHgv.java
+++ b/src/test/java/testresults/PostTestResultsProvisionalUpdateFirstTestHgv.java
@@ -129,9 +129,9 @@ public class PostTestResultsProvisionalUpdateFirstTestHgv {
         vehicleTechnicalRecordsSteps.statusCodeShouldBe(200);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].vin", randomVin);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].systemNumber", systemNumber);
-        vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].techRecord.size()", 2);
+        vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].techRecord.size()", 1);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
-                ("[0].techRecord.findAll { it.statusCode == 'removed' }.size()", 1);
+                ("[0].techRecord.findAll { it.statusCode == 'removed' }.size()", 0);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
                 ("[0].techRecord.findAll { it.statusCode == 'current' }.size()", 1);
     }

--- a/src/test/java/testresults/PostTestResultsProvisionalUpdateFirstTestHgv.java
+++ b/src/test/java/testresults/PostTestResultsProvisionalUpdateFirstTestHgv.java
@@ -131,7 +131,7 @@ public class PostTestResultsProvisionalUpdateFirstTestHgv {
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].systemNumber", systemNumber);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe("[0].techRecord.size()", 2);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
-                ("[0].techRecord.findAll { it.statusCode == 'archived' }.size()", 1);
+                ("[0].techRecord.findAll { it.statusCode == 'removed' }.size()", 1);
         vehicleTechnicalRecordsSteps.valueForFieldInPathShouldBe
                 ("[0].techRecord.findAll { it.statusCode == 'current' }.size()", 1);
     }


### PR DESCRIPTION
## Description

The logic for the promotion of a provisional tech record to a current tech record has now changed. Previously, the existing provisional record would have it's status set to `archived` and a new `current` tech record was added to the tech record array.

Now, the `provisional` tech record to be archived will have it's status set to `removed` and will no longer appear in the API response of the `getTechRecords` endpoint as it is not meant to be a part of the tech record history. A new `current` tech record is still added to the tech record history as it did previously.

Related issue: [CB2-6669](https://dvsa.atlassian.net/browse/CB2-6669)

Automation Results:
[FULL](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2494/DVSA_20CVS_20Backend_20Automation/) - 4 Failures which when passed when ran locally
[ANNUAL_CERT](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2489/DVSA_20CVS_20Backend_20Automation/)
[EXPIRY_DATES](https://jenkins.cvs.dvsacloud.uk/job/UPDATE__BRANCH/job/job_feature_test_backend/2488/DVSA_20CVS_20Backend_20Automation/)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
