### PR TITLE
VTA-1169 - Changed day of month to max values for leap year failing t…

### DIFF
--- a/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousHgv_11396.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousHgv_11396.java
@@ -458,7 +458,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousHgv_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
@@ -884,7 +884,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousHgv_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousHgv_twoValid_11396.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousHgv_twoValid_11396.java
@@ -245,7 +245,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousHgv_twoValid_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateTwo.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDateTwo.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousTrl_11396.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousTrl_11396.java
@@ -458,7 +458,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousTrl_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
@@ -886,8 +886,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousTrl_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).toInstant().toString();
-
+        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousTrl_twoValid_11396.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousTrl_twoValid_11396.java
@@ -245,7 +245,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousTrl_twoValid_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateTwo.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDateTwo.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesHgv_12215.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesHgv_12215.java
@@ -457,7 +457,7 @@ public class PostTestResultsFirstExpiryDatesHgv_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String regnDate = submittedRegnDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = regAnniversary.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = regAnniversary.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationRegnDate = new JsonPathAlteration("$.regnDate", regnDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesTrl_12215.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesTrl_12215.java
@@ -364,7 +364,7 @@ public class PostTestResultsFirstExpiryDatesTrl_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String firstUseDate = submittedFirstUseDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = firstAnniversary.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = firstAnniversary.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationFirstUseDate = new JsonPathAlteration("$.firstUseDate", firstUseDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateHgv_5862.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateHgv_5862.java
@@ -293,7 +293,7 @@ public class PostTestResultsPreservationExpiryDateHgv_5862 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = insertedTestExpiryDate.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDate.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);

--- a/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateTrl_5862.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateTrl_5862.java
@@ -292,7 +292,7 @@ public class PostTestResultsPreservationExpiryDateTrl_5862 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = insertedTestExpiryDate.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDate.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);


### PR DESCRIPTION


## Description

This amends the functionality in creating expiry date to all for leap years

Related issue: [VTA-1169](https://dvsa.atlassian.net/browse/VTA-1169)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
