### PR TITLE
VTA-1244 - Added leap year functionality to extra tests

### DIFF
--- a/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousHgv_11396.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousHgv_11396.java
@@ -245,7 +245,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousHgv_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousTrl_11396.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsExpiryDateBasedOnPreviousTrl_11396.java
@@ -245,7 +245,7 @@ public class PostTestResultsExpiryDateBasedOnPreviousTrl_11396 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated expiry date
-        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDateOne.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         // Create alteration to add one more tech record to in the request body
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesHgv_12215.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesHgv_12215.java
@@ -265,7 +265,7 @@ public class PostTestResultsFirstExpiryDatesHgv_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String regnDate = submittedRegnDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationRegnDate = new JsonPathAlteration("$.regnDate", regnDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
@@ -361,7 +361,7 @@ public class PostTestResultsFirstExpiryDatesHgv_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String regnDate = submittedRegnDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationRegnDate = new JsonPathAlteration("$.regnDate", regnDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
@@ -553,7 +553,7 @@ public class PostTestResultsFirstExpiryDatesHgv_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String regnDate = submittedRegnDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = regAnniversary.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = regAnniversary.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationRegnDate = new JsonPathAlteration("$.regnDate", regnDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
@@ -649,7 +649,7 @@ public class PostTestResultsFirstExpiryDatesHgv_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String regnDate = submittedRegnDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationRegnDate = new JsonPathAlteration("$.regnDate", regnDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesNegativeTrl_12982.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesNegativeTrl_12982.java
@@ -187,7 +187,7 @@ public class PostTestResultsFirstExpiryDatesNegativeTrl_12982 {
         String randomTestResultId = UUID.randomUUID().toString();
         String firstUseDate = "2020-0";
 
-        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
         JsonPathAlteration alterationTestEndTimestamp = new JsonPathAlteration("$.testEndTimestamp", testEndTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesTrl_12215.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsFirstExpiryDatesTrl_12215.java
@@ -270,7 +270,7 @@ public class PostTestResultsFirstExpiryDatesTrl_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String firstUseDate = submittedFirstUseDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationFirstUseDate = new JsonPathAlteration("$.firstUseDate", firstUseDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
@@ -459,7 +459,7 @@ public class PostTestResultsFirstExpiryDatesTrl_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String firstUseDate = submittedFirstUseDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = firstAnniversary.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = firstAnniversary.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationFirstUseDate = new JsonPathAlteration("$.firstUseDate", firstUseDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");
@@ -554,7 +554,7 @@ public class PostTestResultsFirstExpiryDatesTrl_12215 {
         String randomTestResultId = UUID.randomUUID().toString();
         String firstUseDate = submittedFirstUseDate.toInstant().toString().substring(0,10);
 
-        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String expectedTestExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         JsonPathAlteration alterationFirstUseDate = new JsonPathAlteration("$.firstUseDate", firstUseDate, "", "REPLACE");
         JsonPathAlteration alterationTestStartTimestamp = new JsonPathAlteration("$.testStartTimestamp", testStartTimestamp, "", "REPLACE");

--- a/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateHgv_5862.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateHgv_5862.java
@@ -151,7 +151,7 @@ public class PostTestResultsPreservationExpiryDateHgv_5862 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);
@@ -435,7 +435,7 @@ public class PostTestResultsPreservationExpiryDateHgv_5862 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = insertedTestExpiryDate.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDate.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);

--- a/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateNegativeTrl_12982.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateNegativeTrl_12982.java
@@ -150,7 +150,7 @@ public class PostTestResultsPreservationExpiryDateNegativeTrl_12982 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);
@@ -292,7 +292,7 @@ public class PostTestResultsPreservationExpiryDateNegativeTrl_12982 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);
@@ -437,7 +437,7 @@ public class PostTestResultsPreservationExpiryDateNegativeTrl_12982 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);

--- a/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateTrl_5862.java
+++ b/src/test/java/testresults/expiry_date/PostTestResultsPreservationExpiryDateTrl_5862.java
@@ -150,7 +150,7 @@ public class PostTestResultsPreservationExpiryDateTrl_5862 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).toInstant().toString();
+        String testExpiryDate = submittedEndTimestamp.dayOfMonth().withMaximumValue().plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);
@@ -434,7 +434,7 @@ public class PostTestResultsPreservationExpiryDateTrl_5862 {
         String testEndTimestamp = submittedEndTimestamp.toInstant().toString();
 
         // Expected recalculated testExpiryDate
-        String testExpiryDate = insertedTestExpiryDate.plusYears(1).toInstant().toString();
+        String testExpiryDate = insertedTestExpiryDate.plusYears(1).dayOfMonth().withMaximumValue().toInstant().toString();
 
         System.out.println("\n******************************************************");
         System.out.println("Inserted testCode: " + insertedTestCode);


### PR DESCRIPTION
This fixes the 200 plus failing tests in the pack which have leap day as the expiry.

Related issue: [VTA-1244](https://dvsa.atlassian.net/browse/VTA-1244)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
